### PR TITLE
PR #1 feedback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 authors = ["{{authors}}"]
 edition = "2021"
 description = "a nushell plugin called {{ plugin_name }}"
+{% if github_username != empty -%}
 repository = "https://github.com/{{ github_username }}/{{ project-name }}"
+{% endif -%}
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "nu_plugin_{{ plugin_name }}"
+name = "{{ project-name }}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 edition = "2021"
 description = "a nushell plugin called {{ plugin_name }}"
+repository = "https://github.com/{{ github_username }}/{{ project-name }}"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,26 +1,42 @@
 # nu_plugin_template
 
-This is a starter plugin. It just lays out one way to make nushell plugins with nushell version 0.72.0
+This template is intended to be used with [cargo-generate](https://github.com/cargo-generate/cargo-generate) in order to quickly bootstrap nushell plugin projects.
 
-This template is intended to be used with [cargo-generate](https://github.com/cargo-generate/cargo-generate) in order to quickly
-bootstrap nushell plugin projects.
+You must run `cargo generate` with `--force`.
 
 ## Usage:
 
 ```
-> cargo generate --git https://github.com/fdncred/nu_plugin_template
-Project Name: <you choose a name here like nu-plugin-random>
-What should we call the plugin struct?: <you chose a name like RandomStruct>
-What is the name of this plugin package? <you choose a name like random>
-> cd nu-plugin-random
+> cargo generate --force --git https://github.com/fdncred/nu_plugin_template
+🤷   What will this plugin be named?: foo
+Creating a new plugin named "foo"
+Your plugin crate will be named "nu_plugin_foo".
+
+Note that the MIT license is used by default, to reflect the majority of                  
+Nushell projects. You can change this manually if you'd like to.
+                                                        
+!!! IMPORTANT !!!                            
+You must run cargo generate with --force, or it will rename your project to
+something that is non-standard for Nushell plugins and this will fail.
+                                                        
+If you see a message after this about renaming your project, please abort and
+try again with --force.     
+                                                        
+🔧   Destination: /var/home/devyn/Projects/nushell/nu_plugin_foo ...
+🔧   project-name: nu_plugin_foo ...
+🔧   Generating template ...          
+🤷   What should your first command be called? (spaces are okay): foo
+✔ 🤷   Do you intend to create more than one command / subcommand? · No 
+✔ 🤷   Would you like a simple command? Say no if you would like to use streaming. · Yes
+🤷   What is your GitHub username? (Leave blank if you don't want to publish to GitHub) [default: ]: 
+🔧   Moving generated files into: `/var/home/devyn/Projects/nushell/nu_plugin_foo`...
+🔧   Initializing a fresh Git repository      
+✨   Done! New project created /var/home/devyn/Projects/nushell/nu_plugin_foo
+> cd nu_plugin_foo
 > cargo build
-
-# You only need to run this once per nushell session, or after updating the
-# signature of the plugin.
-> register ./target/debug/nu-plugin-random
-
-> 'pas' | random faux
-Hello, faux! with value: pas
+> register target/debug/nu_plugin_foo
+> foo Ferris
+Hello, Ferris. How are you today?
 ```
 
 ## Config values
@@ -28,9 +44,18 @@ Hello, faux! with value: pas
 - `plugin_name` - all nushell plugins are binaries with the name format
 `nu_plugin_SOMETHING`. This is how nushell discovers them. You need to tell this
 generator what that `SOMETHING` is. If you enter `random` as the plugin name,
-your binary will be called `nu_plugin_random`, and you will run it by entering
-`random`.
+your binary will be called `nu_plugin_random`.
 
-- `plugin_struct` - name of the struct that implements the `Plugin` trait from
-`nu-plugin` crate.
+- `command_name` - the name of your first/only command. This can be any valid nushell command name,
+and can contain spaces. For example, if you're creating a format plugin for `FORMAT` files, you
+might choose to go with `from FORMAT` or `to FORMAT`.
+
+- `multi_commmand` - set to `Yes` if you expect that you'll be creating more than one command, in
+which case we'll create a `commands` module for you and put the command in there. Set to `No` if you
+would rather just have everything in `src/main.rs`.
+
+- `command_is_simple` - set to `Yes` if you want a `SimplePluginCommand` with no streaming support,
+or `No` if you want `PluginCommand` with a streaming example.
+
+- `github_username` - we'll use this to set the repository field in `Cargo.toml` if you set it.
 

--- a/README.md.liquid
+++ b/README.md.liquid
@@ -1,0 +1,33 @@
+# {{ project-name }}
+
+This is a [Nushell](https://nushell.sh/) plugin called "{{ plugin_name }}".
+
+## Installing
+
+```nushell
+> cargo install --path .
+```
+
+## Usage
+
+FIXME: This reflects the demo functionality generated with the template. Update this documentation
+once you have implemented the actual plugin functionality.
+
+```nushell
+> register ~/.cargo/bin/{{ project-name }}
+{% if command_is_simple -%}
+> {{ command_name }} Ferris
+Hello, Ferris. How are you today?
+> {{ command_name }} --shout Ferris
+HELLO, FERRIS. HOW ARE YOU TODAY?
+{%- else -%}
+> [ Ferris ] | {{ command_name }}
+╭───┬───────────────────────────────────╮
+│ 0 │ Hello, Ferris. How are you today? │
+╰───┴───────────────────────────────────╯
+> [ Ferris ] | {{ command_name }} --shout
+╭───┬───────────────────────────────────╮
+│ 0 │ HELLO, FERRIS. HOW ARE YOU TODAY? │
+╰───┴───────────────────────────────────╯
+{%- endif %}
+```

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,10 +1,15 @@
-[placeholders.plugin_name]
-type = "string"
-prompt = "What is the name of this plugin package? (will automatically be prefixed by nu_plugin_)"
-
 [placeholders.command_name]
 type = "string"
 prompt = "What should your first command be called? (spaces are okay)"
+
+[placeholders.single_command]
+type = "string"
+prompt = "Do you intend to create more than one command / subcommand?"
+choices = [
+  "Yes",
+  "No"
+]
+default = "No"
 
 [placeholders.command_is_simple]
 type = "string"
@@ -14,5 +19,11 @@ choices = [
   "No"
 ]
 
+[placeholders.github_username]
+type = "string"
+prompt = "What is your GitHub username? (Leave blank if you don't want to publish to GitHub)"
+default = ""
+
 [hooks]
-pre = ["setup.rhai"]
+init = ["init.rhai"]
+pre = ["pre.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -2,7 +2,7 @@
 type = "string"
 prompt = "What should your first command be called? (spaces are okay)"
 
-[placeholders.single_command]
+[placeholders.multi_command]
 type = "string"
 prompt = "Do you intend to create more than one command / subcommand?"
 choices = [
@@ -27,3 +27,6 @@ default = ""
 [hooks]
 init = ["init.rhai"]
 pre = ["pre.rhai"]
+
+[conditional.'multi_command == "No"']
+ignore = ["src/commands"]

--- a/init.rhai
+++ b/init.rhai
@@ -1,0 +1,26 @@
+let plugin_name = variable::prompt("What will this plugin be named?").to_snake_case();
+
+if plugin_name.starts_with("nu_plugin_") {
+    plugin_name.replace("nu_plugin_", "");
+}
+
+if plugin_name.is_empty() {
+    abort("Plugin name must not be empty.");
+}
+
+variable::set("plugin_name", plugin_name);
+variable::set("project-name", "nu_plugin_" + plugin_name);
+
+print(`Creating a new plugin named "${variable::get("plugin_name")}"`);
+print(`Your plugin crate will be named "${variable::get("project-name")}".`);
+print("");
+print("Note that the MIT license is used by default, to reflect the majority of");
+print("Nushell projects. You can change this manually if you'd like to.");
+print("");
+print("!!! IMPORTANT !!!");
+print("You must run cargo generate with --force, or it will rename your project to");
+print("something that is non-standard for Nushell plugins and this will fail.");
+print("");
+print("If you see a message after this about renaming your project, please abort and");
+print("try again with --force.");
+print("");

--- a/pre.rhai
+++ b/pre.rhai
@@ -1,3 +1,8 @@
+if variable::get("project-name").contains("-") {
+    abort("Please run cargo generate with --force, so that we can set the crate name to\n\
+        something starting with `nu_plugin_`.");
+}
+
 variable::set("plugin_struct", variable::get("plugin_name").to_pascal_case() + "Plugin");
 variable::set("command_struct", variable::get("command_name").to_pascal_case());
 variable::set("command_module", variable::get("command_name").to_snake_case());

--- a/src/commands/{{command_module}}.rs
+++ b/src/commands/{{command_module}}.rs
@@ -12,7 +12,7 @@ use crate::{{ plugin_struct }};
 
 pub struct {{ command_struct }};
 
-{% if command_is_simple == "Yes" %}
+{% if command_is_simple == "Yes" -%}
 impl SimplePluginCommand for {{ command_struct }} {
     type Plugin = {{ plugin_struct }};
 
@@ -50,7 +50,7 @@ impl SimplePluginCommand for {{ command_struct }} {
         Ok(Value::string(greeting, call.head))
     }
 }
-{% else %}
+{%- else -%}
 impl PluginCommand for {{ command_struct }} {
     type Plugin = {{ plugin_struct }};
 
@@ -100,4 +100,4 @@ impl PluginCommand for {{ command_struct }} {
         }, None)?)
     }
 }
-{% endif %}
+{%- endif %}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,20 @@
 use nu_plugin::{MsgPackSerializer, Plugin, PluginCommand, serve_plugin};
-
+{% if multi_command == "No" -%}
+{%- if command_is_simple == "Yes" -%}
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, SimplePluginCommand};
+use nu_protocol::{Category, PluginExample, PluginSignature, SyntaxShape, Value};
+{%- else -%}
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, PluginCommand};
+use nu_protocol::{
+    Category, PipelineData, PluginExample, PluginSignature, Type, Value,
+};
+{%- endif %}
+{%- else %}
 mod commands;
 pub use commands::*;
+{%- endif %}
 
 pub struct {{ plugin_struct }};
-
-impl {{ plugin_struct }} {
-    fn new() -> Self {
-        Self {}
-    }
-}
 
 impl Plugin for {{ plugin_struct }} {
     fn commands(&self) -> Vec<Box<dyn PluginCommand<Plugin = Self>>> {
@@ -20,6 +25,100 @@ impl Plugin for {{ plugin_struct }} {
     }
 }
 
+{% if multi_command == "No" -%}
+pub struct {{ command_struct }};
+
+{% if command_is_simple == "Yes" -%}
+impl SimplePluginCommand for {{ command_struct }} {
+    type Plugin = {{ plugin_struct }};
+
+    fn signature(&self) -> PluginSignature {
+        PluginSignature::build("{{ command_name }}")
+            .required("name", SyntaxShape::String, "(FIXME) A demo parameter - your name")
+            .switch("shout", "(FIXME) Yell it instead", None)
+            .plugin_examples(vec![
+                PluginExample {
+                    example: "{{ command_name }} Ferris".into(),
+                    description: "Say hello to Ferris".into(),
+                    result: Some(Value::test_string("Hello, Ferris. How are you today?")),
+                },
+                PluginExample {
+                    example: "{{ command_name }} --shout Ferris".into(),
+                    description: "Shout hello to Ferris".into(),
+                    result: Some(Value::test_string("HELLO, FERRIS. HOW ARE YOU TODAY?")),
+                },
+            ])
+            .category(Category::Experimental)
+    }
+
+    fn run(
+        &self,
+        _plugin: &{{ plugin_struct }},
+        _engine: &EngineInterface,
+        call: &EvaluatedCall,
+        _input: &Value,
+    ) -> Result<Value, LabeledError> {
+        let name: String = call.req(0)?;
+        let mut greeting = format!("Hello, {name}. How are you today?");
+        if call.has_flag("shout")? {
+            greeting = greeting.to_uppercase();
+        }
+        Ok(Value::string(greeting, call.head))
+    }
+}
+{%- else -%}
+impl PluginCommand for {{ command_struct }} {
+    type Plugin = {{ plugin_struct }};
+
+    fn signature(&self) -> PluginSignature {
+        PluginSignature::build("{{ command_name }}")
+            .switch("shout", "(FIXME) Yell it instead", None)
+            .input_output_type(Type::List(Type::String.into()), Type::List(Type::String.into()))
+            .plugin_examples(vec![
+                PluginExample {
+                    example: "[ Ferris ] | {{ command_name }}".into(),
+                    description: "Say hello to Ferris".into(),
+                    result: Some(Value::test_list(vec![
+                        Value::test_string("Hello, Ferris. How are you today?")
+                    ])),
+                },
+                PluginExample {
+                    example: "[ Ferris ] | {{ command_name }} --shout".into(),
+                    description: "Shout hello to Ferris".into(),
+                    result: Some(Value::test_list(vec![
+                        Value::test_string("HELLO, FERRIS. HOW ARE YOU TODAY?")
+                    ])),
+                },
+            ])
+            .category(Category::Experimental)
+    }
+
+    fn run(
+        &self,
+        _plugin: &{{ plugin_struct }},
+        _engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let span = call.head;
+        let shout = call.has_flag("shout")?;
+        Ok(input.map(move |name| {
+            match name.as_str() {
+                Ok(name) => {
+                    let mut greeting = format!("Hello, {name}. How are you today?");
+                    if shout {
+                        greeting = greeting.to_uppercase();
+                    }
+                    Value::string(greeting, span)
+                }
+                Err(err) => Value::error(err, span),
+            }
+        }, None)?)
+    }
+}
+{%- endif %}
+
+{% endif -%}
 fn main() {
-    serve_plugin(&{{ plugin_struct }}::new(), MsgPackSerializer);
+    serve_plugin(&{{ plugin_struct }}, MsgPackSerializer);
 }


### PR DESCRIPTION
I think this addresses everything you brought up in #1 

- Plugin name is asked for, and project name is generated automatically (but `--force` is required to have `cargo generate` do the right thing). Turns out this was possible
- README updated
- project actually gets a generated README too
- option to have everything in main.rs, instead of a commands module
- ask for GitHub username, add `repository` if present
