### PR TITLE
update to 0.97.2 (description vs usage)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ license = "MIT"
 # for local development, you can use a path dependency
 # nu-plugin = { path = "../nushell/crates/nu-plugin" }
 # nu-protocol = { path = "../nushell/crates/nu-protocol", features = ["plugin"] }
-nu-plugin = "0.96.0"
-nu-protocol = { version = "0.96.0", features = ["plugin"] }
+nu-plugin = "0.97.1"
+nu-protocol = { version = "0.97.1", features = ["plugin"] }
 
 [dev-dependencies]
 # nu-plugin-test-support = { path = "../nushell/crates/nu-plugin-test-support" }
-nu-plugin-test-support = { version = "0.96.0" }
+nu-plugin-test-support = { version = "0.97.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ license = "MIT"
 # for local development, you can use a path dependency
 # nu-plugin = { path = "../nushell/crates/nu-plugin" }
 # nu-protocol = { path = "../nushell/crates/nu-protocol", features = ["plugin"] }
-nu-plugin = "0.97.1"
-nu-protocol = { version = "0.97.1", features = ["plugin"] }
+nu-plugin = "0.97.2"
+nu-protocol = { version = "0.97.2", features = ["plugin"] }
 
 [dev-dependencies]
 # nu-plugin-test-support = { path = "../nushell/crates/nu-plugin-test-support" }
-nu-plugin-test-support = { version = "0.97.1" }
+nu-plugin-test-support = { version = "0.97.2" }

--- a/src/commands/{{command_module}}.rs
+++ b/src/commands/{{command_module}}.rs
@@ -25,7 +25,7 @@ impl SimplePluginCommand for {{ command_struct }} {
             .category(Category::Experimental)
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "(FIXME) help text for {{ command_name }}"
     }
 
@@ -74,7 +74,7 @@ impl PluginCommand for {{ command_struct }} {
             .category(Category::Experimental)
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "(FIXME) help text for {{ command_name }}"
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ impl SimplePluginCommand for {{ command_struct }} {
             .category(Category::Experimental)
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "(FIXME) help text for {{ command_name }}"
     }
 
@@ -96,7 +96,7 @@ impl PluginCommand for {{ command_struct }} {
             .category(Category::Experimental)
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "(FIXME) help text for {{ command_name }}"
     }
 


### PR DESCRIPTION
This PR updates the template to match the nushell repo, 0.97.2. The main change was `usage()` changed to `description()`.